### PR TITLE
Update beaglebone-freq.txt

### DIFF
--- a/beaglebone/beaglebone-freq.txt
+++ b/beaglebone/beaglebone-freq.txt
@@ -1,69 +1,67 @@
 # BeagleBone BSMP update frequencies
 
-# names not showing here use default freq values [Hz] (see model_factory.py):
-#
-# PSMODEL               SYNC_OFF[SCAN]_FREQUENCY[Hz]  SYNC_ON[RAMP]_FREQUENCY[Hz]
-# FBP                     10.0                           2.0
-# FBP_DCLink               2.0                           2.0
-# FAC                     10.0                           2.0
+# PSMODEL               FREQUENCY[Hz]
+# FBP                     10.0
+# FBP_DCLink               2.0
+# FAC                     10.0
 
-# BBBNAME|UDC           SYNC_OFF[SCAN]_FREQUENCY[Hz]  SYNC_ON[RAMP]_FREQUENCY[Hz]
+# BBBNAME|UDC           FREQUENCY[Hz]
 
 # --- BO B-1 pwrsupply
-PA-RaPSE05:PS-UDC-BO1     10.0                           5.0
+PA-RaPSE05:PS-UDC-BO1     10.0
 # --- BO B-1 pwrsupply dclinks
-PA-RaPSE05:PS-UDC-BO2      1.0                           1.0
-PA-RaPSE05:PS-UDC-BO3      1.0                           1.0
-PA-RaPSE05:PS-UDC-BO4      1.0                           1.0
-PA-RaPSE05:PS-UDC-BO5      1.0                           1.0
+PA-RaPSE05:PS-UDC-BO2      1.0
+PA-RaPSE05:PS-UDC-BO3      1.0
+PA-RaPSE05:PS-UDC-BO4      1.0
+PA-RaPSE05:PS-UDC-BO5      1.0
 
 # --- BO B-2 pwrsupply
-PA-RaPSF05:PS-UDC-BO1     10.0                           5.0
+PA-RaPSF05:PS-UDC-BO1     10.0
 # --- BO B-2 pwrsupply dclinks
-PA-RaPSF05:PS-UDC-BO2      1.0                           1.0
-PA-RaPSF05:PS-UDC-BO3      1.0                           1.0
-PA-RaPSF05:PS-UDC-BO4      1.0                           1.0
-PA-RaPSF05:PS-UDC-BO5      1.0                           1.0
+PA-RaPSF05:PS-UDC-BO2      1.0
+PA-RaPSF05:PS-UDC-BO3      1.0
+PA-RaPSF05:PS-UDC-BO4      1.0
+PA-RaPSF05:PS-UDC-BO5      1.0
 
 # --- BO QF pwrsupply
-PA-RaPSC03:PS-UDC-BO2     10.0                           5.0
+PA-RaPSC03:PS-UDC-BO2     10.0
 # --- BO QF pwrsupply dclinks
-PA-RaPSC03:PS-UDC-BO1      1.0                           1.0
+PA-RaPSC03:PS-UDC-BO1      1.0
 
 # --- BO QD pwrsupply
-PA-RaPSC03:PS-UDC-BO5     10.0                           5.0
+PA-RaPSC03:PS-UDC-BO5     10.0
 # --- BO SF pwrsupply
-PA-RaPSC03:PS-UDC-BO3     10.0                           5.0
+PA-RaPSC03:PS-UDC-BO3     10.0
 # --- BO SD pwrsupply
-PA-RaPSC03:PS-UDC-BO4     10.0                           5.0
+PA-RaPSC03:PS-UDC-BO4     10.0
 
 # --- BO correctors ---
-IA-01RaCtrl:CO-PSCtrl-BO   5.0                           5.0
-IA-02RaCtrl:CO-PSCtrl-BO   5.0                           5.0
-IA-04RaCtrl:CO-PSCtrl-BO   5.0                           5.0
-IA-05RaCtrl:CO-PSCtrl-BO   5.0                           5.0
-IA-07RaCtrl:CO-PSCtrl-BO   5.0                           5.0
-IA-08RaCtrl:CO-PSCtrl-BO   5.0                           5.0
-IA-10RaCtrl:CO-PSCtrl-BO   5.0                           5.0
-IA-11RaCtrl:CO-PSCtrl-BO   5.0                           5.0
-IA-13RaCtrl:CO-PSCtrl-BO   5.0                           5.0
-IA-14RaCtrl:CO-PSCtrl-BO   5.0                           5.0
-IA-16RaCtrl:CO-PSCtrl-BO   5.0                           5.0
-IA-17RaCtrl:CO-PSCtrl-BO   5.0                           5.0
-IA-20RaCtrl:CO-PSCtrl-BO   5.0                           5.0
+IA-01RaCtrl:CO-PSCtrl-BO   5.0
+IA-02RaCtrl:CO-PSCtrl-BO   5.0
+IA-04RaCtrl:CO-PSCtrl-BO   5.0
+IA-05RaCtrl:CO-PSCtrl-BO   5.0
+IA-07RaCtrl:CO-PSCtrl-BO   5.0
+IA-08RaCtrl:CO-PSCtrl-BO   5.0
+IA-10RaCtrl:CO-PSCtrl-BO   5.0
+IA-11RaCtrl:CO-PSCtrl-BO   5.0
+IA-13RaCtrl:CO-PSCtrl-BO   5.0
+IA-14RaCtrl:CO-PSCtrl-BO   5.0
+IA-16RaCtrl:CO-PSCtrl-BO   5.0
+IA-17RaCtrl:CO-PSCtrl-BO   5.0
+IA-20RaCtrl:CO-PSCtrl-BO   5.0
 
 # --- TS corrector pwrsupplies
 # NOTE: request CON to change BBB name from "-TB3" to "-AS"
-LA-RaCtrl:CO-PSCtrl-TB3    5.0                           2.0
+LA-RaCtrl:CO-PSCtrl-TB3    5.0
 
 # --- TB quadrupoles pwrsupplies
-LA-RaCtrl:CO-PSCtrl-TB1    2.0                           2.0
+LA-RaCtrl:CO-PSCtrl-TB1    5.0
 
 # --- TB corrector pwrsupplies
-LA-RaCtrl:CO-PSCtrl-TB2    2.0                           2.0
+LA-RaCtrl:CO-PSCtrl-TB2    5.0
 
 # --- TS corrector pwrsupplies
-LA-RaCtrl:CO-PSCtrl-TS4    5.0                           2.0
+LA-RaCtrl:CO-PSCtrl-TS4    5.0
 
 # --- TB quad and corrs and TS corr dclinks
-LA-RaCtrl:CO-PSCtrl-AS     5.0                           2.0
+LA-RaCtrl:CO-PSCtrl-AS     5.0


### PR DESCRIPTION
- There is no distinction between _Sync_Off_ and _Sync_On_ update frequencies in the new PS IOCs code.
- Increase update freq for TB quads and corrs from 2 Hz to 5 Hz.