### PR TITLE
Add new MKS vacuum gauge controller in section 08

### DIFF
--- a/beaglebone/control-system-beaglebone.json
+++ b/beaglebone/control-system-beaglebone.json
@@ -238,7 +238,7 @@
 
     "108": {
         "MKS": [
-            {"BBB_IP_1": "10.128.108.101", "BBB_IP_2": "", "BBB_HOSTNAME": "BBB-SALA08-VAC-MKS", "DEVICE_TYPE": "MKS", "DEVICE_ID": [1, 2, 3, 4], "DEVICE_NAME": ""},
+            {"BBB_IP_1": "10.128.108.101", "BBB_IP_2": "", "BBB_HOSTNAME": "BBB-SALA08-VAC-MKS", "DEVICE_TYPE": "MKS", "DEVICE_ID": [1, 2, 3, 4, 6], "DEVICE_NAME": ""},
             {"BBB_IP_1": "10.128.108.107", "BBB_IP_2": "", "BBB_HOSTNAME": "BBB-SALA08-IVU-MKS", "DEVICE_TYPE": "MKS", "DEVICE_ID": [5], "DEVICE_NAME": ""}
             ],
         "4UHV": [


### PR DESCRIPTION
On Monday (June 9), we (Patricia, Tainara and me) configured a new MKS vacuum gauge controller in section 08.

The new controller was connected to the BeagleBone Black at IP `10.128.108.101`, which already had four MKS controllers assigned to addresses 1, 2, 3, and 4. Since address 5 was already in use by another MKS controller connected to a different BBB in section 08, we assigned address 6 to the new controller to avoid address conflicts.  

This pull request updates the `control-system-beaglebone.json` file to reflect this new configuration, ensuring proper communication with the newly installed controller.
